### PR TITLE
Breaking change to verify

### DIFF
--- a/src/api.pact.spec.js
+++ b/src/api.pact.spec.js
@@ -17,10 +17,10 @@ describe('API Pact test', () => {
   describe('retrieving a product', () => {
     test('ID 10 exists', async () => {
       // Arrange
-      const expectedProduct = { id: '10', type: 'CREDIT_CARD', name: '28 Degrees'}
+      // const expectedProduct = { id: '10', type: 'CREDIT_CARD', name: '28 Degrees'}
 
       // Uncomment to see this fail
-      // const expectedProduct = { id: '10', type: 'CREDIT_CARD', name: '28 Degrees', price: 30.0, newField: 22}
+      const expectedProduct = { id: '10', type: 'CREDIT_CARD', name: '28 Degrees', price: 30.0, newField: 22}
 
       await mockProvider.addInteraction({
         state: 'a product with ID 10 exists',


### PR DESCRIPTION
_DO NOT MERGE - Demo Purposes only_

This is an unsafe change - it adds a `newField` field to the consumer expectation.

It will trigger a provider verification as a `contract_requiring_verification_published` event is generated, when the pact is published

https://github.com/pactflow/example-provider/actions/workflows/contract_requiring_verification_published.yml